### PR TITLE
Fix broken link in index.mdx

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -64,7 +64,7 @@ export function Link({ title, url, description, index }) {
   <div className="grid md:grid-cols-4 grid-cols-1 gap-4 pt-10 pb-4 mx-auto">
       <Link index={2} url="https://fabric.moddedmc.wiki/" title="Fabric Modding Wiki" description="A great resource for anyone looking to create Minecraft mods using the Fabric Loader."/>
       <Link index={3} url="https://forge.moddedmc.wiki" title="Forge Community Wiki (gemwire)" description="A great resource for anyone looking to create Minecraft mods using the Forge Loader."/>
-      <Link index={4} url="https://github.com/moddedmc/awesome-moddedmc" title="Awesome Modded Minecraft" description="An 'awesome' collection of tools, guides and resources related to modding Minecraft: Java Edition."/>
+      <Link index={4} url="https://github.com/moddedmc-wiki/awesome-moddedmc" title="Awesome Modded Minecraft" description="An 'awesome' collection of tools, guides and resources related to modding Minecraft: Java Edition."/>
       <Motioner index={5}>
         <div className="h-full text-white max-w-xs my-auto rounded-xl transition-all duration-500 bg-gradient-to-tl from-neutral-400 via-neutral-500 to-neutral-800 bg-size-200 bg-pos-0 hover:bg-pos-100 p-4 py-5 px-5">
           <h3 className="text-md font-bold">Blog</h3>


### PR DESCRIPTION
Currently, the "Awesome Modded Minecraft" in [moddedmc.wiki](https://moddedmc.wiki/) links to [moddedmc/awesome-moddedmc](https://github.com/moddedmc/awesome-moddedmc). This repository has been moved to [moddedmc-wiki/awesome-moddedmc](https://github.com/moddedmc-wiki/awesome-moddedmc) but the link was left broken. This PR fixes this.